### PR TITLE
Fix rotating tools animation

### DIFF
--- a/src/sections/home/HeroSection/RotatingTools.tsx
+++ b/src/sections/home/HeroSection/RotatingTools.tsx
@@ -74,9 +74,9 @@ export const RotatingTools = () => {
       </AnimatePresence>
       {/* Logos orbiting around */}
       <span
-        className="absolute inset-0 flex items-center justify-center"
+        className="absolute inset-0 flex items-center justify-center animate-spin"
         aria-hidden="true"
-        style={{ animation: "spin 20s linear infinite" }}
+        style={{ animationDuration: "20s" }}
       >
         {TOOLS.map((tool, idx) => {
           const angle = (idx / TOOLS.length) * 360;


### PR DESCRIPTION
## Summary
- use Tailwind's `animate-spin` class for rotating tools

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6887893ffdec832090e041de0ef651fb