### PR TITLE
feat: add GA event tracking for extension downloads

### DIFF
--- a/src/app/[locale]/stripe-checkout/page.tsx
+++ b/src/app/[locale]/stripe-checkout/page.tsx
@@ -14,11 +14,17 @@ import { trackEvent } from "@/lib/analytics"
 function StripeCheckoutContent() {
   const searchParams = useSearchParams()
   const t = useTranslations('payment')
-  
+
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
-  
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.gtag) {
+      window.gtag('event', 'manual_event_PURCHASE', {})
+    }
+  }, [])
+
   useEffect(() => {
     const verifySession = async () => {
       try {

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -8,7 +8,7 @@ import { useTranslations } from 'next-intl'
 import { useTheme } from "next-themes"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 
 const Footer = () => {
   const t = useTranslations('footer')
@@ -241,8 +241,8 @@ const Footer = () => {
             &copy; {new Date().getFullYear()} Jaydai. {t('allRightsReserved')}
           </p>
           <div className="mt-4 md:mt-0">
-            <a 
-              onClick={() => {
+            <a
+              onClick={(e) => {
                 trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                   button_name: 'footerLink_downloadExtension',
                   page_location: window.location.pathname,
@@ -250,9 +250,11 @@ const Footer = () => {
                   timestamp: new Date().toISOString()
                 })
                 if (isMobile) {
+                  e.preventDefault()
                   open()
                 } else {
-                  window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                  e.preventDefault()
+                  gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                 }
               }}
             >

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -9,7 +9,7 @@ import { useTranslations } from 'next-intl'
 import { Link, useRouter } from '@/lib/navigation'
 import { useLocale } from 'next-intl'
 import LanguageSwitcher from "@/components/common/LanguageSwitcher"
-import { trackEvent } from "@/lib/analytics"
+import { trackEvent, gtagSendEvent } from "@/lib/analytics"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useExtensionModal } from "@/components/common/ExtensionModalContext"
 
@@ -253,9 +253,9 @@ const Navbar = () => {
                 {t('requestDemo')}
               </a>
             ) : (
-              <a 
+              <a
                 className="flex items-center gap-2 font-bold whitespace-nowrap text-xs lg:text-sm px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                onClick={() => {
+                onClick={(e) => {
                   trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                     button_name: 'navbarDownloadExtension',
                     page_location: window.location.pathname,
@@ -263,9 +263,11 @@ const Navbar = () => {
                     timestamp: new Date().toISOString()
                   })
                   if (isMobile) {
+                    e.preventDefault()
                     open()
                   } else {
-                    window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                    e.preventDefault()
+                    gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                   }
                 }}
               >
@@ -433,9 +435,9 @@ const Navbar = () => {
                 {t('requestDemo')}
               </a>
             ) : (
-              <a 
+              <a
                 className="flex items-center gap-2 font-bold whitespace-nowrap text-sm px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                onClick={() => {
+                onClick={(e) => {
                   trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                     button_name: 'navbarDownloadExtension',
                     page_location: window.location.pathname,
@@ -443,9 +445,11 @@ const Navbar = () => {
                     timestamp: new Date().toISOString()
                   })
                   if (isMobile) {
+                    e.preventDefault()
                     open()
                   } else {
-                    window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                    e.preventDefault()
+                    gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                   }
                 }}
               >

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -31,6 +31,29 @@ export function trackPageView(path: string) {
   }
 }
 
+/**
+ * Send a Google Analytics event and delay navigation until it's recorded
+ * @param url - URL to open after the event is sent
+ */
+export function gtagSendEvent(url: string) {
+  const callback = () => {
+    if (typeof url === 'string') {
+      window.open(url, '_blank')
+    }
+  }
+
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'Download Extension', {
+      event_callback: callback,
+      event_timeout: 2000,
+    })
+  } else {
+    callback()
+  }
+
+  return false
+}
+
 // Extend gtag typing for client-side tracking
 declare global {
   interface Window {

--- a/src/sections/blog/BlogPostCallToAction/index.tsx
+++ b/src/sections/blog/BlogPostCallToAction/index.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { motion } from 'framer-motion'
 import { useTranslations } from 'next-intl'
 import { ArrowRight, Star, ChevronRight } from 'lucide-react'
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
 
@@ -101,6 +101,9 @@ const BlogPostCallToAction: React.FC<BlogPostCallToActionProps> = ({
                     if (isMobile) {
                       e.preventDefault()
                       open()
+                    } else {
+                      e.preventDefault()
+                      gtagSendEvent(href)
                     }
                   }}
                   className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-colors ${

--- a/src/sections/home/AnalyticsDashboardSection/index.tsx
+++ b/src/sections/home/AnalyticsDashboardSection/index.tsx
@@ -8,7 +8,7 @@ import DashboardViewer from "./DashboardViewer"
 import SectionHeader from "./SectionHeader"
 import Link from "next/link"
 import Image from "next/image"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
 
@@ -73,6 +73,9 @@ const AnalyticsDashboardSection = () => {
             if (isMobile) {
               e.preventDefault()
               open()
+            } else {
+              e.preventDefault()
+              gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
             }
           }}
         >

--- a/src/sections/home/BeforeAfterComparison/index.tsx
+++ b/src/sections/home/BeforeAfterComparison/index.tsx
@@ -6,7 +6,7 @@ import Image from "next/image"
 import { ArrowLeftRight } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useTheme } from "next-themes"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
 import Link from "next/link"
@@ -177,6 +177,9 @@ const BeforeAfterComparison = () => {
                 if (isMobile) {
                   e.preventDefault()
                   open()
+                } else {
+                  e.preventDefault()
+                  gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                 }
               }}
             >

--- a/src/sections/home/FeaturesSection/index.tsx
+++ b/src/sections/home/FeaturesSection/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react"
 import { useTranslations } from "next-intl"
 import Link from "next/link"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from "@/components/common/ExtensionModalContext"
 
@@ -113,7 +113,7 @@ const FeaturesSection = () => {
             <a
               target="_blank"
               className="px-8 py-3 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium"
-              onClick={() => {
+              onClick={(e) => {
                 trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                   button_name: 'homeFeaturesDownloadExtension',
                   page_location: window.location.pathname,
@@ -121,9 +121,11 @@ const FeaturesSection = () => {
                   timestamp: new Date().toISOString()
                 })
                 if (isMobile) {
+                  e.preventDefault()
                   open()
                 } else {
-                  window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                  e.preventDefault()
+                  gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                 }
               }}
             >

--- a/src/sections/home/HeroSection/HeroContent.tsx
+++ b/src/sections/home/HeroSection/HeroContent.tsx
@@ -3,7 +3,7 @@
 import React from "react"
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { motion } from "framer-motion"
 import { Play } from "lucide-react"
 import { ShimmerButton } from "@/components/ui/shimmer-button"
@@ -76,7 +76,7 @@ const HeroContent: React.FC<HeroContentProps> = ({
           if (isMobile) {
             open()
           } else {
-            window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+            gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
           }
         }}
           className="px-8 py-3 rounded-md text-primary-foreground font-black"

--- a/src/sections/home/HowItWorksSection/index.tsx
+++ b/src/sections/home/HowItWorksSection/index.tsx
@@ -17,7 +17,7 @@ import {
   X
 } from "lucide-react"
 import Link from "next/link"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
 const HowItWorksSection = () => {
@@ -327,6 +327,9 @@ const HowItWorksSection = () => {
               if (isMobile) {
                 e.preventDefault()
                 open()
+              } else {
+                e.preventDefault()
+                gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
               }
             }}
             className="px-8 py-3 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium inline-flex items-center gap-2"

--- a/src/sections/home/PricingSection/index.tsx
+++ b/src/sections/home/PricingSection/index.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import { Check, ArrowRight, Building2 } from "lucide-react";
 import { ShimmerButton } from "@/components/ui/shimmer-button";
 import { useTranslations } from "next-intl";
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from '@/components/common/ExtensionModalContext'
 
@@ -24,10 +24,7 @@ export default function PricingSection() {
     if (isMobile) {
       open()
     } else {
-      window.open(
-        "https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd",
-        "_blank"
-      )
+      gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
     }
   }
 

--- a/src/sections/home/TemplatesSection/index.tsx
+++ b/src/sections/home/TemplatesSection/index.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from "react"
 import { motion, useScroll, useTransform } from "framer-motion"
 import { useTranslations } from "next-intl"
 import { ArrowRight } from "lucide-react"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from "@/components/common/ExtensionModalContext"
 
@@ -165,7 +165,7 @@ const TemplatesSection = () => {
                 <p className="text-foreground/70 mb-4">{category.description}</p>
                 <a
                   href="#"
-                  onClick={() => {
+                  onClick={(e) => {
                     trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                       button_name: `homeTemplatesExplore_${category.id}`,
                       page_location: window.location.pathname,
@@ -173,9 +173,11 @@ const TemplatesSection = () => {
                       timestamp: new Date().toISOString()
                     })
                     if (isMobile) {
+                      e.preventDefault()
                       open()
                     } else {
-                      window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                      e.preventDefault()
+                      gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
                     }
                   }}
                   className={`inline-flex items-center ${category.textColor} hover:underline`}
@@ -204,7 +206,7 @@ const TemplatesSection = () => {
           
           <a
             target="_blank"
-            onClick={() => {
+            onClick={(e) => {
               trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                 button_name: 'homeTemplatesCta',
                 page_location: window.location.pathname,
@@ -212,14 +214,16 @@ const TemplatesSection = () => {
                 timestamp: new Date().toISOString()
               })
               if (isMobile) {
+                e.preventDefault()
                 open()
               } else {
-                window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                e.preventDefault()
+                gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
               }
             }}
             className="px-8 py-3 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium"
           >
-            {t('ctaButtonText')} 
+            {t('ctaButtonText')}
           </a>
         </motion.div>
       </div>

--- a/src/sections/home/TestimonialSection/index.tsx
+++ b/src/sections/home/TestimonialSection/index.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion"
 import Image from "next/image"
 import { useTranslations } from "next-intl"
 import { Star, Quote, ArrowUpRight } from "lucide-react"
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, gtagSendEvent } from '@/lib/analytics'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useExtensionModal } from "@/components/common/ExtensionModalContext"
 
@@ -161,7 +161,7 @@ const TestimonialsSection = () => {
           </p>
           
           <a
-            onClick={() => {
+            onClick={(e) => {
               trackEvent(`${isMobile ? 'Mobile Download Extension' : 'Download Extension'}`, {
                 button_name: 'homeTestimonialsSectionCta',
                 page_location: window.location.pathname,
@@ -169,16 +169,18 @@ const TestimonialsSection = () => {
                 timestamp: new Date().toISOString()
               })
               if (isMobile) {
+                e.preventDefault()
                 open()
               } else {
-                window.open("https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd", "_blank")
+                e.preventDefault()
+                gtagSendEvent('https://chromewebstore.google.com/detail/jaydai-chrome-extension/enfcjmbdbldomiobfndablekgdkmcipd')
               }
             }}
             target="_blank"
             className="px-8 py-3 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium"
-            style={{ 
-              backgroundColor: "rgb(99, 102, 241)", 
-              color: "white" 
+            style={{
+              backgroundColor: "rgb(99, 102, 241)",
+              color: "white"
             }} // Explicit styling for button
           >
             {t('cta.buttonText')}


### PR DESCRIPTION
## Summary
- fire `manual_event_PURCHASE` when Stripe checkout page loads
- add helper to send delayed GA events for extension downloads
- trigger GA download event from extension CTAs across site

## Testing
- `pnpm lint` *(fails: interactive ESLint configuration prompt)*
- `pnpm build` *(fails: could not fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4cf8548c8320b1a8941dcc1c502a